### PR TITLE
fix: regex wrong for umbrella

### DIFF
--- a/lib/xcribe/config.ex
+++ b/lib/xcribe/config.ex
@@ -107,7 +107,7 @@ defmodule Xcribe.Config do
   defp validate_serve_output({_errors, config} = results) do
     output = Map.fetch!(config, :output)
 
-    if Regex.match?(~r/^priv\/static\/.*/, output) do
+    if Regex.match?(~r/priv\/static\/.*/, output) do
       results
     else
       add_error(results, :output, output, @serve_output_message, @serve_output_instructions)


### PR DESCRIPTION
## Motivation

There was an error in the regex, it would require to start with /priv, but fail with absolute path in umbrella project.

## Proposed solution

remove need to start with /priv.